### PR TITLE
Fix permissions for IBM cloud cli plugin directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh && \
     ibmcloud plugin install container-registry -f && \
     ibmcloud plugin install observe-service -f && \
     if [[ "$TARGETPLATFORM" != "linux/arm64" ]]; then ibmcloud plugin install vpc-infrastructure -f; fi && \
-    ibmcloud config --check-version=false
+    ibmcloud config --check-version=false && \
+    chmod -R g=u ${HOME}


### PR DESCRIPTION
appends a command to set group permissions to user after ibmcloud cli install

Signed-off-by: Tim Robinson <timroster@gmail.com>